### PR TITLE
Fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rakarmp/simagen
+module github.com/rakarmp/simigen
 
 go 1.21.0


### PR DESCRIPTION
There is an error when I tried to add this module.

```go get github.com/rakarmp/simigen
go: github.com/rakarmp/simigen@upgrade (v0.0.0-20230908150508-d21938d9dcf1) requires github.com/rakarmp/simigen@v0.0.0-20230908150508-d21938d9dcf1: parsing go.mod:       
        module declares its path as: github.com/rakarmp/simagen
                but was required as: github.com/rakarmp/simigen
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated module name from `github.com/rakarmp/simagen` to `github.com/rakarmp/simigen`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->